### PR TITLE
[IOS-5527]Update IronSource adapter version to 5.0.0.0

### DIFF
--- a/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.h
+++ b/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.h
@@ -5,7 +5,7 @@
 #import <Foundation/Foundation.h>
 #import "IronSource/ISBaseAdapter+Internal.h"
 
-static NSString * const VungleAdapterVersion = @"5.0.0";
+static NSString * const VungleAdapterVersion = @"5.0.0.0";
 static NSString * GitHash = @"";
 
 //System Frameworks For Vungle Adapter


### PR DESCRIPTION
This PR is updating IronSource adapter version to 5.0.0.0. Since IronSource adapter version always has 4 parts. Below is the IronSource adapter version list in CocoaPods Specs:
<img width="138" alt="Screen Shot 2022-10-26 at 15 50 55" src="https://user-images.githubusercontent.com/37288907/197967216-cadc941c-d96d-4412-b5d2-94f8143e57ac.png">

IOS-5527
