### PR TITLE
[IOS-8016] Added adapter logging

### DIFF
--- a/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.h
+++ b/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <IronSource/ISBaseAdapter+Internal.h>
 
-static NSString * const VungleAdapterVersion = @"5.6.0";
+static NSString * const VungleAdapterVersion = @"5.7.0";
 static NSString * Githash = @"";
 
 //System Frameworks For Vungle Adapter

--- a/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.m
+++ b/Adapters/Vungle/ISVungleAdapter/ISVungleAdapter.m
@@ -355,6 +355,7 @@ static InitState initState = INIT_STATE_NONE;
 
     VungleRewarded *rewardedVideoAd = [[VungleRewarded alloc] initWithPlacementId:placementId];
     rewardedVideoAd.delegate = rewardedVideoAdDelegate;
+    rewardedVideoAd.adapterAdFormat = kAdapterFormatRewarded;
 
     // Add rewarded video ad to dictionary
     [self.rewardedVideoPlacementIdToAd setObject:rewardedVideoAd
@@ -501,6 +502,7 @@ static InitState initState = INIT_STATE_NONE;
 
     VungleInterstitial *interstitialAd = [[VungleInterstitial alloc] initWithPlacementId:placementId];
     interstitialAd.delegate = interstitialAdDelegate;
+    interstitialAd.adapterAdFormat = kAdapterFormatInterstitial;
 
     // Add interstitial ad to dictionary
     [self.interstitialPlacementIdToAd setObject:interstitialAd
@@ -664,10 +666,20 @@ static InitState initState = INIT_STATE_NONE;
         
         // set delegate
         vungleBannerView.delegate = bannerAdDelegate;
-        
+        vungleBannerView.adapterAdFormat = kAdapterFormatBanner;
+
+        // log custom banner size mismatch for non-inline placements
+        if (![VungleAds isInLine:placementId] &&
+            [size.sizeDescription isEqualToString:kSizeCustom]) {
+            vungleBannerView.adapterAdFormat = [kAdapterFormatBanner stringByAppendingFormat:@"-%@", size.sizeDescription];
+            NSString *message = [NSString stringWithFormat:@"CustomBannerSizeMismatch:w-%ld|h-%ld",
+                                 (long)size.width, (long)size.height];
+            [VungleMediationLogger logErrorForAd:vungleBannerView message:message];
+        }
+
         [self.bannerPlacementIdToAd setObject:vungleBannerView
                                        forKey:placementId];
-        
+
         // load banner
         [vungleBannerView load:serverData];
     });

--- a/Adapters/Vungle/ISVungleAdapter/ISVungleConstant.h
+++ b/Adapters/Vungle/ISVungleAdapter/ISVungleConstant.h
@@ -14,6 +14,11 @@ static NSString * const kAppId                  = @"AppID";
 static NSString * const kPlacementId            = @"PlacementId";
 static NSString * const kCreativeId             = @"creativeId";
 
+// Adapter ad format identifiers
+static NSString * const kAdapterFormatRewarded      = @"ISVungleRewardedVideo";
+static NSString * const kAdapterFormatInterstitial   = @"ISVungleInterstitial";
+static NSString * const kAdapterFormatBanner         = @"ISVungleBanner";
+
 // Meta data flags
 static NSString * const kMetaDataCOPPAKey       = @"Vungle_COPPA";
 

--- a/Adapters/Vungle/Podfile
+++ b/Adapters/Vungle/Podfile
@@ -3,6 +3,6 @@
 
 target 'ISVungleAdapter' do
   pod 'IronSourceSDK', '9.3.0.0'
-  pod 'VungleAds', '7.7.1'
+  pod 'VungleAds', '7.7.2'
 
 end


### PR DESCRIPTION
This commit will add adapter logging (phase 1 items)
- Add `adapterAdFormat`
- Log custom banner size mismatch case through `MediationLogger`
- Support Liftoff IOS SDK 7.7.2

[IOS-8016](https://vungle.atlassian.net/browse/IOS-8016)

[IOS-8016]: https://vungle.atlassian.net/browse/IOS-8016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ